### PR TITLE
Revise copy

### DIFF
--- a/index-2.html
+++ b/index-2.html
@@ -32,14 +32,14 @@
     <div id="bottom" class="clearfix">
       <div class="container">
         <div class="left">
-          <h3>But really, what even <i>is</i> boxen?</h3>
-          <p>Boxen itself is a RubyGem that provides a method for managing and running a Boxen project. The real “meat” is in the boxen/our-boxen template project. This template is designed for you to fork under your user or organization as a private fork and customize it to your needs.</p>
+          <h3>But really, what <i>is</i> Boxen?</h3>
+          <p>Boxen was extracted from an internal tool we built at GitHub to manage all the dependencies for our applications. With Boxen, any of our employees can run any of our apps with just a one-line command. We don't have to worry about installing dependencies, configuring databases, or running processes; it all just works.</p>
 
-          <h3>What can boxen do?</h3>
-          <p>While Boxen provides a basic development environment that includes tools like nvm, rbenv, hub, dnsmasq, nginx, several ruby and nodejs versions, and more, the real power is in the exensibility of the system. </p>            
+          <h3>What can Boxen do?</h3>
+          <p>Boxen handles all the nitty-gritty so you don't have to. You'll define the dependencies for your app, and Boxen leverages <a href="https://github.com/puppetlabs/puppet">Puppet</a> to install and manage those dependencies for your team. Once you've created a template for your organization, everyone can pitch in and collaborate to improve the environment for everyone else.</p>
 
-          <h3>How do I get my org on boxen?</h3>
-          <p>Using the number of Puppet modules we’ve already created under the @boxen organization, you can simply add these modules to the Puppetfile in your fork, update your manifests, and run it. For specific user configuration, we also provide documentation on how to create personal manifests and project manifests. Combining all of these allows for a sane way of managing your whole laptop, even if you want to configure and install certain things that your whole organization doesn’t need to.</p>
+          <h3>How do I get my team on Boxen?</h3>
+          <p>Using the number of Puppet modules we’ve already created under the @boxen organization, you can simply add these modules to the Puppetfile in your fork, update your manifests, and run it. For specific user configuration, we also provide documentation on how to create personal manifests and project manifests. Combining all of these allows for a sane way of managing your whole laptop, even if you want to configure and install certain things that your whole organization doesn't need to.</p>
         </div>
         <div class="right">
           <div class="screenshot terminal"></div>


### PR DESCRIPTION
Whew, copy is hard.

![Screen Shot 2013-01-02 at 10 11 30 PM](https://f.cloud.github.com/assets/2723/39924/a46ef080-555b-11e2-94e8-bdfe9373354f.png)

This updates the tagline, header copy, and the first two buckets on the bottom. I'd like @wfarr to rewrite that- I didn't know enough about how we're distributing Boxen to detail that.

Since we don't have an "Install" page on boxen.github.com proper, do we have a nice fat `README` or wiki somewhere that details all this? That's the problem with Hubot, in part: lots of repositories, lots of different components to touch, and not a solid one-page how-to guide. I think a nice install and customization guide would go a long way as marketing for how everything fits together, too: right now it's a bit nebulous.

/cc @nrrrdcore
